### PR TITLE
Add gcc and kconfig-frontends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-Support for building MotoMods on OS X
+homebrew-motomods
+=================
+
+MotoMods-related Homebrew formula for developers using OS X
+
+Contact: mdk-help@motorola.com

--- a/gcc-arm-none-eabi-47.rb
+++ b/gcc-arm-none-eabi-47.rb
@@ -1,0 +1,13 @@
+require 'formula'
+
+class GccArmNoneEabi47 < Formula
+  homepage 'https://launchpad.net/gcc-arm-embedded'
+  version '20140408'
+  url 'http://launchpadlibrarian.net/174121504/gcc-arm-none-eabi-4_7-2014q2-20140408-mac.tar.bz2'
+  sha256 'b2ed364a0be3eeda86a5eaeaff529b8189ef6afebe62802663af782537deb857'
+
+  def install 
+    ohai 'Copying binaries...'
+    system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
+  end
+end

--- a/gcc-arm-none-eabi-48.rb
+++ b/gcc-arm-none-eabi-48.rb
@@ -1,0 +1,13 @@
+require 'formula'
+
+class GccArmNoneEabi48 < Formula
+  homepage 'https://launchpad.net/gcc-arm-embedded'
+  version '20140805'
+  url 'http://launchpadlibrarian.net/186124092/gcc-arm-none-eabi-4_8-2014q3-20140805-mac.tar.bz2'
+  sha256 '6b30901738b09a8d22fdfff99e991217444b80ac492a6163af5c06a3baaa3487'
+
+  def install 
+    ohai 'Copying binaries...'
+    system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
+  end
+end

--- a/gcc-arm-none-eabi-49.rb
+++ b/gcc-arm-none-eabi-49.rb
@@ -1,0 +1,13 @@
+require 'formula'
+
+class GccArmNoneEabi49 < Formula
+  homepage 'https://launchpad.net/gcc-arm-embedded'
+  version '20150925'
+  url 'https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2'
+  sha256 'a6353db31face60c2091c2c84c902fc4d566decd1aa04884cd822c383d13c9fa'
+
+  def install
+    ohai 'Copying binaries...'
+    system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
+  end
+end

--- a/gcc-arm-none-eabi.rb
+++ b/gcc-arm-none-eabi.rb
@@ -1,0 +1,13 @@
+require 'formula'
+
+class GccArmNoneEabi < Formula
+  homepage 'https://launchpad.net/gcc-arm-embedded'
+  version '20140805'
+  url 'http://launchpadlibrarian.net/186124092/gcc-arm-none-eabi-4_8-2014q3-20140805-mac.tar.bz2'
+  sha256 '6b30901738b09a8d22fdfff99e991217444b80ac492a6163af5c06a3baaa3487'
+
+  def install
+    ohai 'Copying binaries...'
+    system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
+  end
+end

--- a/kconfig-frontends.rb
+++ b/kconfig-frontends.rb
@@ -1,0 +1,25 @@
+require 'formula'
+
+class KconfigFrontends < Formula
+  homepage ''
+  url 'http://ymorin.is-a-geek.org/download/kconfig-frontends/kconfig-frontends-3.12.0.0.tar.xz'
+  version '3.12.0.0'
+  sha256 'ea2615a62c74bea6ce3b38402f00c7513858f307f6ba7aa9fdbf0bbc12bcf407'
+
+  depends_on 'xz' => :build
+  depends_on 'automake' => :build
+  depends_on 'autoconf' => :build
+  depends_on 'libtool' => :build
+  depends_on 'pkgconfig' => :build
+
+  def install
+    system "./bootstrap"
+    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make install" # if this fails, try separate make/make install steps
+  end
+
+  def test
+    system "kconfig-conf"
+  end
+end


### PR DESCRIPTION
Add gcc and kconfig-frontends tools for core MotoMods development.

Signed-off-by: Mike Corrigan <corrigan@motorola.com>